### PR TITLE
metricGroup field was missing

### DIFF
--- a/hikari-jmx.json
+++ b/hikari-jmx.json
@@ -14,6 +14,7 @@
     17,
     18
   ],
+  "metricGroup": "hikari.plugins",
   "metrics": [
     {
       "timeseries": {


### PR DESCRIPTION
After import, I get the following message

The metricGroup field is missing. Since version 1.172, the metric group is an obligatory field. It is used for grouping custom metrics into a hierarchical namespace where various sources, for example multiple extensions, can provide data. Moreover, the metric group becomes a primary part of the metric key, which means that once defined, it must remain the same for the continuity of data. For more information, see:  [[JSON reference](https://dynatrace.github.io/plugin-sdk/api/plugin_json_apidoc.html#metadata)]